### PR TITLE
Add ${DESTDIR} to the /etc dir for server.pub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ strip: $(PRPL_LIBNAME)
 # TODO: Find a better place for server.pub
 install: $(PRPL_LIBNAME)
 	install -D $(PRPL_LIBNAME) $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_LIBNAME)
-	install -D tg-server.pub /etc/telegram-purple/server.pub
+	install -D tg-server.pub $(DESTDIR)/etc/telegram-purple/server.pub
 	install -D purple-plugin/telegram16.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/telegram.png
 	install -D purple-plugin/telegram22.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/telegram.png
 	install -D purple-plugin/telegram48.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/telegram.png
@@ -95,7 +95,7 @@ install: $(PRPL_LIBNAME)
 .PHONY: uninstall
 uninstall:
 	rm -f $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_LIBNAME)
-	rm -f /etc/telegram-purple/server.pub
+	rm -f $(DESTDIR)/etc/telegram-purple/server.pub
 	rm -f $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/telegram.png
 	rm -f $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/telegram.png
 	rm -f $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/telegram.png


### PR DESCRIPTION
When making [this AUR package](https://aur.archlinux.org/packages/telegram-purple-git/) saw that ${DESTDIR} was missing. It's a little patch but hey :)
