### PR TITLE
Bugfix: always respect $(DESTDIR) in Makefile

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -64,7 +64,7 @@ strip: $(PRPL_LIBNAME)
 # TODO: Find a better place for server.pub
 install: $(PRPL_LIBNAME)
 	install -D $(PRPL_LIBNAME) $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
-	install -D tg-server.pub /etc/telegram-purple/server.pub
+	install -D tg-server.pub $(DESTDIR)/etc/telegram-purple/server.pub
 	install -D imgs/telegram16.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/telegram.png
 	install -D imgs/telegram22.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/telegram.png
 	install -D imgs/telegram48.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/telegram.png
@@ -76,7 +76,7 @@ local_install:
 .PHONY: uninstall
 uninstall:
 	rm -f $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
-	rm -f /etc/telegram-purple/server.pub
+	rm -f $(DESTDIR)/etc/telegram-purple/server.pub
 	rm -f $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/telegram.png
 	rm -f $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/telegram.png
 	rm -f $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/telegram.png


### PR DESCRIPTION
Currently $(DESTDIR) wouldn't be considered for `/etc/telegram-purple/server.pub` when executing `make install`