### PR TITLE
Fix install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -62,11 +62,11 @@ strip: $(PRPL_LIBNAME)
 .PHONY: install
 install: $(PRPL_LIBNAME)
 	mkdir -p $(DESTDIR)/etc/telegram-purple
-	install $(PRPL_LIBNAME) $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
-	install tg-server.pub $(DESTDIR)/etc/telegram-purple/server.pub
-	install imgs/telegram16.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/telegram.png
-	install imgs/telegram22.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/telegram.png
-	install imgs/telegram48.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/telegram.png
+	install -Dm 0755 $(PRPL_LIBNAME) $(DESTDIR)$(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
+	install -Dm 0644 tg-server.pub $(DESTDIR)/etc/telegram-purple/server.pub
+	install -Dm 0644 imgs/telegram16.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/telegram.png
+	install -Dm 0644 imgs/telegram22.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/telegram.png
+	install -Dm 0644 imgs/telegram48.png $(DESTDIR)$(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/telegram.png
 
 .PHONY: local_install
 local_install:


### PR DESCRIPTION
hello, this is the fix for the next problem:
make DESTDIR=/var/tmp/portage/net-im/telegram-purple-9999/image/ install 
mkdir -p /var/tmp/portage/net-im/telegram-purple-9999/image//etc/telegram-purple
install bin/telegram-purple.so /var/tmp/portage/net-im/telegram-purple-9999/image//usr/lib/purple-2/telegram-purple.so
install: cannot create regular file ‘/var/tmp/portage/net-im/telegram-purple-9999/image//usr/lib/purple-2/telegram-purple.so’: No such file or directory