### PR TITLE
using fedora's dnf instead of deprecated yum

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository has submodules, so you need to clone recursively.
 
 ##### Fedora
 
-        sudo yum install gcc openssl-devel glib2-devel libpurple-devel libwebp-devel
+        sudo dnf install gcc openssl-devel glib2-devel libpurple-devel libwebp-devel
 
 
 ###### Debian / Ubuntu


### PR DESCRIPTION
Please use dnf. It's available since Fedora 18 and replaces yum in Fedora 22 and above. See https://fedoraproject.org/wiki/Changes/ReplaceYumWithDNF for details.