### PR TITLE
Some minor build improvements

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,7 @@ DIR_PERM=0755
 FILE_PERM=0644
 
 CC=@CC@
+PKG_CONFIG=@PKG_CONFIG@
 
 DEP=dep
 AUTO=auto
@@ -28,8 +29,8 @@ PRPL_NAME=telegram-purple.so
 PRPL_LIBNAME=${EXE}/${PRPL_NAME}
 all: ${PRPL_LIBNAME}
 
-PLUGIN_DIR_PURPLE=$(shell pkg-config --variable=plugindir purple)
-DATA_ROOT_DIR_PURPLE=$(shell pkg-config --variable=datarootdir purple)
+PLUGIN_DIR_PURPLE=$(shell ${PKG_CONFIG} --variable=plugindir purple)
+DATA_ROOT_DIR_PURPLE=$(shell ${PKG_CONFIG} --variable=datarootdir purple)
 
 include ${srcdir}/Makefile.tl-parser
 include ${srcdir}/Makefile.tgl

--- a/Makefile.tgl
+++ b/Makefile.tgl
@@ -8,6 +8,8 @@ GENERATE_OBJECTS=${OBJ}/generate.o
 TGL_COMMON_OBJECTS=${OBJ}/tools.o
 TGL_OBJ_C=${GENERATE_OBJECTS} ${TGL_COMMON_OBJECTS} ${TGL_OBJECTS} ${TLD_OBJECTS}
 
+AR?=ar
+
 .SUFFIXES:
 
 .SUFFIXES: .c .h .o
@@ -26,7 +28,7 @@ ${TGL_OBJECTS_AUTO}: ${OBJ}/auto/%.o: ${AUTO}/%.c | create_dirs
 #	${CC} ${INCLUDE} ${COMPILE_FLAGS} -iquote ${srcdir}/tgl -c -MP -MD -MF ${DEP}/auto/auto.d -MQ ${OBJ}/auto/auto.o -o $@ $<
 
 ${LIB}/libtgl.a: ${TGL_OBJECTS} ${TGL_COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
-	rm -f $@ && ar ruv $@ $^
+	rm -f $@ && ${AR} ruv $@ $^
 
 ${EXE}/generate: ${GENERATE_OBJECTS} ${TGL_COMMON_OBJECTS}
 	${CC} ${GENERATE_OBJECTS} ${TGL_COMMON_OBJECTS} ${LINK_FLAGS} -o $@


### PR DESCRIPTION
Just two small fixes for build issues I ran into while trying to package this plugin for Exherbo Linux.

The first one makes use of the pkg-config command found during the run of ./configure in the Makefile to find the {plugin,dataroot}dir of purple.
The second one allows the 'ar' command to be defined during make by passing AR to the make call or set is as environment variable.