### PR TITLE
Last beta4 update for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This repository has submodules, so you need to clone recursively.
 
 ##### Fedora
 
-        sudo dnf install gcc libgcrypt-devel glib2-devel libpurple-devel libwebp-devel
+        sudo dnf install gcc gettext libgcrypt-devel libwebp-devel libpurple-devel zlib-devel
 
 
 ###### Debian / Ubuntu

--- a/rpm/purple-telegram.spec
+++ b/rpm/purple-telegram.spec
@@ -1,13 +1,13 @@
 Name:		purple-telegram
 Version:	1.2.1
-Release:	2%{?dist}
+Release:	3%{?dist}
 Summary:	Adds support for Libpurple based messengers
 Group:		Applications/Internet
 License:	GPLv2+
 URL:		https://github.com/majn/telegram-purple
 Source0:	https://codeload.github.com/majn/telegram-purple/tar.gz/v%{version}.tar.gz
 
-BuildRequires:	openssl-devel,glib2-devel,libpurple-devel,libwebp-devel
+BuildRequires:	gettext, libgcrypt-devel, pkgconfig(zlib), pkgconfig(purple), pkgconfig(libwebp)
 
 %description
 Adds support for Telegram to Pidgin, Adium, Finch 
@@ -23,8 +23,9 @@ make %{?_smp_mflags}
 %install
 %make_install
 chmod 755 %{buildroot}/%{_libdir}/purple-2/telegram-purple.so
+%find_lang telegram-purple
 
-%files
+%files -f telegram-purple.lang
 %doc README* CHANGELOG* 
 %{_libdir}/purple-2/telegram-purple.so
 %config %{_sysconfdir}/telegram-purple/*
@@ -33,6 +34,11 @@ chmod 755 %{buildroot}/%{_libdir}/purple-2/telegram-purple.so
 %{_datadir}/pixmaps/pidgin/protocols/48/telegram.png
 
 %changelog
+* Wed Oct 14 2015 tuxmaster 1.2.1-3
+- Use the better pkconfig for build requires.
+- Add translations.
+- Switch to libgcrypt from openssl.
+
 * Wed Sep 30  2015 tuxmaster 1.2.1-2
 - fix unneeded hard requirements
 - source code fix not required anymore (better to fix the code)


### PR DESCRIPTION
- Use the better pkconfig for build requires.
- Add translations.
- Switch to libgcrypt from openssl.
- Modify Readme for the new requirements of the build for Fedora.