### PR TITLE
Allow compiling on Windows

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -1,0 +1,148 @@
+srcdir=.
+gettext_package=telegram-purple
+
+PURPLE_VERSION = 2.10.11
+PIDGIN_TREE_TOP := ../pidgin-$(PURPLE_VERSION)
+WIN32_DEV_TOP = $(PIDGIN_TREE_TOP)/../win32-dev
+
+CFLAGS=-I$(WIN32_DEV_TOP)/libgcrypt-1.6.3/include -I$(WIN32_DEV_TOP)/libgpg-error-1.12-2/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include/glib-2.0 -I$(WIN32_DEV_TOP)/glib-2.28.8/lib/glib-2.0/include -I$(PIDGIN_TREE_TOP)/libpurple -I$(WIN32_DEV_TOP)/libwebp-0.4.3-1/include -DHAVE_CONFIG_H -DENABLE_NLS -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -I${srcdir} -I. -fno-strict-aliasing
+LDFLAGS=-L$(WIN32_DEV_TOP)/libgcrypt-1.6.3/lib -L$(WIN32_DEV_TOP)/libwebp-0.4.3-1/lib -L$(WIN32_DEV_TOP)/gettext-0.18/bin -L$(PIDGIN_TREE_TOP)/libpurple -L$(WIN32_DEV_TOP)/glib-2.28.8/lib -L$(WIN32_DEV_TOP)/libwebp-0.4.3-1/lib -lpurple -lintl -lglib-2.0 -lwebp -lz -lgcrypt -Wl,--export-all-symbols -ggdb -lws2_32 -static-libgcc
+DIR_PERM=0755
+FILE_PERM=0644
+
+CC = $(WIN32_DEV_TOP)/mingw/bin/gcc
+PKG_CONFIG=
+
+DEP=dep
+EXE=bin
+OBJ=objs
+LIB=libs
+DIR_LIST=${DEP} ${EXE} ${OBJ} ${LIB} ${DEP}/lodepng ${OBJ}/lodepng
+
+PLUGIN_OBJECTS=${OBJ}/tgp-net.o ${OBJ}/tgp-timers.o ${OBJ}/msglog.o ${OBJ}/telegram-base.o ${OBJ}/telegram-purple.o ${OBJ}/tgp-2prpl.o ${OBJ}/tgp-structs.o ${OBJ}/tgp-utils.o ${OBJ}/tgp-chat.o ${OBJ}/tgp-ft.o ${OBJ}/tgp-msg.o ${OBJ}/tgp-request.o ${OBJ}/tgp-blist.o ${OBJ}/lodepng/lodepng.o
+ALL_OBJS=${PLUGIN_OBJECTS}
+
+LOCALES=$(patsubst %.po, %.mo, $(wildcard po/*.po))
+
+.SUFFIXES:
+
+.SUFFIXES: .c .h .o
+
+PRPL_NAME=libtelegram.dll
+PRPL_LIBNAME=${EXE}/${PRPL_NAME}
+all: ${PRPL_LIBNAME} ${LOCALES}
+
+PLUGIN_DIR_PURPLE="$(PROGRAMFILES)/Pidgin/plugins"
+DATA_ROOT_DIR_PURPLE="$(PROGRAMFILES)/Pidgin"
+COPY_ICONS=yes
+localedir=$(DATA_ROOT_DIR_PURPLE)/locale
+
+create_dirs: ${DIR_LIST}
+
+${DIR_LIST}:
+	@test -d $@ || mkdir -p $@
+
+DEPENDENCE=$(subst ${OBJ}/,${DEP}/,$(patsubst %.o,%.d,${ALL_OBJS}))
+DEPENDENCE_LIST=${DEPENDENCE}
+-include ${DEPENDENCE_LIST}
+
+
+# The dependency on tgl/libs/libtgl.a ensures that "make -C tgl" was called,
+# and most importantly: It ensures that all automatic headers exist.
+${PLUGIN_OBJECTS}: ${OBJ}/%.o: ${srcdir}/%.c ${LIB}/libtgl.a | create_dirs
+	echo $@ && ${CC} ${CFLAGS} ${CPPFLAGS} -I ${srcdir}/tgl -I ${srcdir}/lodepng -c -MP -MD -MF ${DEP}/$*.d -MQ ${OBJ}/$*.o -o $@ $<
+
+tgl/Makefile.mingw: ${srcdir}/Makefile.tgl.mingw
+	cp $< $@
+
+tgl/libs/libtgl.a: tgl/Makefile.mingw
+	+make -C tgl -f Makefile.mingw
+
+tgl/config.h: ${srcdir}/config.h.tgl.mingw
+	cp $< $@
+	
+config.h: ${srcdir}/config.h.mingw
+	cp $< $@
+
+po/%.mo: po/%.po
+	$(WIN32_DEV_TOP)/gettext-0.17/bin/msgfmt -cf -o $@ $<
+
+${LIB}/libtgl.a: tgl/libs/libtgl.a | create_dirs
+	cp $< $@
+
+${PRPL_LIBNAME}: ${PLUGIN_OBJECTS} ${LIB}/libtgl.a | create_dirs
+	${CC} -shared -o $@ $^ ${LDFLAGS}
+
+.PHONY: plugin
+plugin: $(PRPL_LIBNAME)
+
+
+.PHONY: strip
+strip: $(PRPL_LIBNAME)
+	$(STRIP) --strip-unneeded $(PRPL_LIBNAME)
+
+.PHONY: install
+install: $(PRPL_LIBNAME) $(LOCALES)
+	mkdir -m $(DIR_PERM) -p $(PLUGIN_DIR_PURPLE)
+	install -m $(FILE_PERM) $(PRPL_LIBNAME) $(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
+	install -m $(FILE_PERM) tg-server.tglpub $(DATA_ROOT_DIR_PURPLE)/server.tglpub
+ifeq ($(COPY_ICONS),no)
+	@echo "Not copying icons due to configure-option --disable-icons."
+	@echo " If you're using Finch, Empathy, or Telepathy, then this is a good idea."
+	@echo " If you're using Pidgin, then this is a bad idea."
+	@echo " If you're using Adium, read the README.md: You're using the wrong build system!"
+else
+	mkdir -m $(DIR_PERM) -p $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16
+	install -m $(FILE_PERM) imgs/telegram16.png $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/telegram.png
+	mkdir -m $(DIR_PERM) -p $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22
+	install -m $(FILE_PERM) imgs/telegram22.png $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/telegram.png
+	mkdir -m $(DIR_PERM) -p $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48
+	install -m $(FILE_PERM) imgs/telegram48.png $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/telegram.png
+endif
+	@for lang in $(shell cat po/LINGUAS); do \
+		mkdir -p $(localedir)/$$lang/LC_MESSAGES; \
+		echo "installing po/$$lang.mo to $(localedir)/$$lang/LC_MESSAGES/$(gettext_package).mo"; \
+		install -m $(FILE_PERM) po/$$lang.mo $(localedir)/$$lang/LC_MESSAGES/$(gettext_package).mo; \
+	done
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(PLUGIN_DIR_PURPLE)/$(PRPL_NAME)
+	rm -f $(DATA_ROOT_DIR_PURPLE)/server.tglpub
+	rm -f $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/16/telegram.png
+	rm -f $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/22/telegram.png
+	rm -f $(DATA_ROOT_DIR_PURPLE)/pixmaps/pidgin/protocols/48/telegram.png
+# TODO: Delete all installed .mo's, no matter what LINGUAS says.
+	@for lang in $(shell cat po/LINGUAS); do \
+		echo "removing $(localedir)/$$lang/LC_MESSAGES/$(gettext_package).mo"; \
+		rm -f $(localedir)/$$lang/LC_MESSAGES/$(gettext_package).mo; \
+	done
+
+.PHONY: local_install
+local_install:
+	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(HOME)/.purple/plugins
+	install -m $(FILE_PERM) $(PRPL_LIBNAME) $(DESTDIR)$(HOME)/.purple/plugins/$(PRPL_NAME)
+# See telegram-base.c, function get_user_pk_path for justification:
+	mkdir -m $(DIR_PERM) -p $(DESTDIR)$(HOME)/.purple/telegram-purple
+	install -m $(FILE_PERM) tg-server.tglpub $(DESTDIR)$(HOME)/.purple/telegram-purple/server.tglpub
+
+.PHONY: local_uninstall
+local_uninstall:
+	rm -f $(DESTDIR)$(HOME)/.purple/plugins/$(PRPL_NAME)
+	rm -f $(DESTDIR)$(HOME)/.purple/telegram-purple/server.tglpub
+
+.PHONY: run
+run:
+	pidgin -d | grep 'telegram\|plugin\|proxy'
+
+.PHONY: debug
+debug: install
+	ddd pidgin
+
+.PHONY: clean-here
+clean-here:
+	rm -rf ${DIR_LIST} $(PRPL_C_OBJS) $(PRPL_LIBNAME) po/*.mo
+
+.PHONY: clean
+clean: clean-here tgl/Makefile.mingw
+	+make -C tgl -f Makefile.mingw clean

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -4,9 +4,12 @@ gettext_package=telegram-purple
 PURPLE_VERSION = 2.10.11
 PIDGIN_TREE_TOP := ../pidgin-$(PURPLE_VERSION)
 WIN32_DEV_TOP = $(PIDGIN_TREE_TOP)/../win32-dev
+MAKENSIS ?= "$(PROGRAMFILES)/NSIS/makensis.exe"
+PLUGIN_VERSION ?= 1.2.2
+GMSGFMT ?= $(WIN32_DEV_TOP)/gettext-0.17/bin/msgfmt
 
-CFLAGS=-I$(WIN32_DEV_TOP)/libgcrypt-1.6.3/include -I$(WIN32_DEV_TOP)/libgpg-error-1.12-2/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include/glib-2.0 -I$(WIN32_DEV_TOP)/glib-2.28.8/lib/glib-2.0/include -I$(PIDGIN_TREE_TOP)/libpurple -I$(WIN32_DEV_TOP)/libwebp-0.4.3-1/include -DHAVE_CONFIG_H -DENABLE_NLS -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -I${srcdir} -I. -fno-strict-aliasing
-LDFLAGS=-L$(WIN32_DEV_TOP)/libgcrypt-1.6.3/lib -L$(WIN32_DEV_TOP)/libwebp-0.4.3-1/lib -L$(WIN32_DEV_TOP)/gettext-0.18/bin -L$(PIDGIN_TREE_TOP)/libpurple -L$(WIN32_DEV_TOP)/glib-2.28.8/lib -L$(WIN32_DEV_TOP)/libwebp-0.4.3-1/lib -lpurple -lintl -lglib-2.0 -lwebp -lz -lgcrypt -Wl,--export-all-symbols -ggdb -lws2_32 -static-libgcc
+CFLAGS=-I$(WIN32_DEV_TOP)/libgcrypt-1.6.3/include -I$(WIN32_DEV_TOP)/libgpg-error-1.12-2/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include/glib-2.0 -I$(WIN32_DEV_TOP)/glib-2.28.8/lib/glib-2.0/include -I$(PIDGIN_TREE_TOP)/libpurple -I$(WIN32_DEV_TOP)/libwebp-0.4.3-1/include -DHAVE_CONFIG_H -DENABLE_NLS -DPACKAGE_VERSION='"$(PLUGIN_VERSION)"' -Wall -Wextra -Werror -Wno-deprecated-declarations -Wno-unused-parameter -I${srcdir} -I. -fno-strict-aliasing
+LDFLAGS=-L$(WIN32_DEV_TOP)/libgcrypt-1.6.3/lib -L$(WIN32_DEV_TOP)/libwebp-0.4.3-1/lib -L$(WIN32_DEV_TOP)/gettext-0.18/bin -L$(PIDGIN_TREE_TOP)/libpurple -L$(WIN32_DEV_TOP)/glib-2.28.8/lib -lpurple -lintl -lglib-2.0 -lwebp -lz -lgcrypt -Wl,--export-all-symbols -ggdb -lws2_32 -static-libgcc
 DIR_PERM=0755
 FILE_PERM=0644
 
@@ -65,7 +68,7 @@ config.h: ${srcdir}/config.h.mingw
 	cp $< $@
 
 po/%.mo: po/%.po
-	$(WIN32_DEV_TOP)/gettext-0.17/bin/msgfmt -cf -o $@ $<
+	$(GMSGFMT) -cf -o $@ $<
 
 ${LIB}/libtgl.a: tgl/libs/libtgl.a | create_dirs
 	cp $< $@
@@ -146,3 +149,7 @@ clean-here:
 .PHONY: clean
 clean: clean-here tgl/Makefile.mingw
 	+make -C tgl -f Makefile.mingw clean
+	
+.PHONY: installer
+installer: telegram-purple.nsi $(PRPL_LIBNAME) $(LOCALES)
+	$(MAKENSIS) -DPLUGIN_VERSION="$(PLUGIN_VERSION)" -DPRPL_NAME="$(PRPL_NAME)" -DWIN32_DEV_TOP="$(WIN32_DEV_TOP)" telegram-purple.nsi

--- a/Makefile.tgl.mingw
+++ b/Makefile.tgl.mingw
@@ -1,0 +1,101 @@
+srcdir=.
+
+SCHEME_VERSION = 38
+ENCRYPTED_SCHEME_VERSION = 23
+
+
+WIN32_DEV_TOP ?= ../../win32-dev
+
+CFLAGS=-I$(WIN32_DEV_TOP)/libgcrypt-1.6.3/include -I$(WIN32_DEV_TOP)/libgpg-error-1.12-2/include -I$(WIN32_DEV_TOP)/glib-2.28.8/include  -DHAVE_CONFIG_H
+LDFLAGS=-L$(WIN32_DEV_TOP)/libgcrypt-1.6.3/lib -I$(WIN32_DEV_TOP)/libgpg-error-1.12-2/lib -L$(WIN32_DEV_TOP)/libwebp-0.4.3-1/lib -L$(WIN32_DEV_TOP)/glib-2.28.8/lib -lwebp -lz -lgcrypt -Wl,--export-all-symbols -ggdb 
+CPPFLAGS=
+DEFS=-DHAVE_CONFIG_H
+COMPILE_FLAGS=${CFLAGS} ${CPFLAGS} ${CPPFLAGS} ${DEFS} -Wall -Wextra -Werror -Wno-deprecated-declarations -fno-strict-aliasing -fno-omit-frame-pointer -ggdb -Wno-unused-parameter
+
+EXTRA_LIBS=-lz -lgcrypt  
+LOCAL_LDFLAGS=-ggdb ${EXTRA_LIBS}
+LINK_FLAGS=${LDFLAGS} ${LOCAL_LDFLAGS}
+
+DEP=dep
+AUTO=auto
+OBJ=objs
+LIB=libs
+EXE=bin
+DIR_LIST=${DEP} ${DEP}/crypto ${AUTO} ${EXE} ${OBJ} ${OBJ}/crypto ${LIB} ${DEP}/auto ${OBJ}/auto
+
+LIB_LIST=${LIB}/libtgl.a ${LIB}/libtgl.dll
+
+TGL_OBJECTS=${OBJ}/mtproto-common.o ${OBJ}/mtproto-client.o ${OBJ}/mtproto-key.o ${OBJ}/queries.o ${OBJ}/structures.o ${OBJ}/binlog.o ${OBJ}/tgl.o ${OBJ}/updates.o ${OBJ}/tg-mime-types.o ${OBJ}/mtproto-utils.o ${OBJ}/crypto/bn_openssl.o ${OBJ}/crypto/bn_altern.o ${OBJ}/crypto/rsa_pem_openssl.o ${OBJ}/crypto/rsa_pem_altern.o ${OBJ}/crypto/md5_openssl.o ${OBJ}/crypto/md5_altern.o ${OBJ}/crypto/sha_openssl.o ${OBJ}/crypto/sha_altern.o ${OBJ}/crypto/aes_openssl.o ${OBJ}/crypto/aes_altern.o 
+TGL_OBJECTS_AUTO=${OBJ}/auto/auto-skip.o ${OBJ}/auto/auto-fetch.o ${OBJ}/auto/auto-store.o ${OBJ}/auto/auto-autocomplete.o ${OBJ}/auto/auto-types.o ${OBJ}/auto/auto-fetch-ds.o  ${OBJ}/auto/auto-free-ds.o ${OBJ}/auto/auto-store-ds.o ${OBJ}/auto/auto-print-ds.o
+TLD_OBJECTS=${OBJ}/dump-tl-file.o
+GENERATE_OBJECTS=${OBJ}/generate.o
+COMMON_OBJECTS=${OBJ}/tools.o ${OBJ}/crypto/rand_openssl.o ${OBJ}/crypto/rand_altern.o ${OBJ}/crypto/err_openssl.o ${OBJ}/crypto/err_altern.o
+OBJ_C=${GENERATE_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS} ${TLD_OBJECTS}
+
+DEPENDENCE=$(subst ${OBJ}/,${DEP}/,$(patsubst %.o,%.d,${OBJ_C}))
+DEPENDENCE_LIST=${DEPENDENCE}
+
+INCLUDE=-I. -I${srcdir}
+CC=$(WIN32_DEV_TOP)/mingw/bin/gcc
+
+.SUFFIXES:
+
+.SUFFIXES: .c .h .o
+
+all: ${LIB_LIST}
+create_dirs_and_headers: ${DIR_LIST}  ${AUTO}/auto-skip.h ${AUTO}/auto-fetch.h ${AUTO}/auto-store.h ${AUTO}/auto-autocomplete.h ${AUTO}/auto-types.h
+create_dirs: ${DIR_LIST}
+dump-tl: ${EXE}/dump-tl-file
+
+#include ${srcdir}/Makefile.tl-parser
+
+${DIR_LIST}:
+	@test -d $@ || mkdir -p $@
+
+-include ${DEPENDENCE_LIST}
+
+${TGL_OBJECTS}: ${AUTO}/constants.h ${AUTO}/auto-skip.h ${AUTO}/auto-fetch.h ${AUTO}/auto-store.h ${AUTO}/auto-autocomplete.h ${AUTO}/auto-types.h ${AUTO}/auto-fetch-ds.h ${AUTO}/auto-free-ds.h ${AUTO}/auto-store-ds.h ${AUTO}/auto-print-ds.h
+
+${OBJ_C}: ${OBJ}/%.o: ${srcdir}/%.c | create_dirs
+	${CC} ${INCLUDE} ${COMPILE_FLAGS} -c -MP -MD -MF ${DEP}/$*.d -MQ ${OBJ}/$*.o -o $@ $<
+
+${TGL_OBJECTS_AUTO}: ${OBJ}/auto/%.o: ${AUTO}/%.c | create_dirs
+	${CC} ${INCLUDE} ${COMPILE_FLAGS} -iquote ${srcdir}/tgl -c -MP -MD -MF ${DEP}/$*.d -MQ ${OBJ}/$*.o -o $@ $<
+
+${LIB}/libtgl.a: ${TGL_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
+	rm -f $@ && ar ruv $@ $^
+
+${LIB}/libtgl.dll: ${TGL_OBJECTS} ${COMMON_OBJECTS} ${TGL_OBJECTS_AUTO}
+	${CC} -shared -o $@ $^ ${LINK_FLAGS}
+
+${EXE}/generate: ${GENERATE_OBJECTS} ${COMMON_OBJECTS}
+	${CC} ${GENERATE_OBJECTS} ${COMMON_OBJECTS} ${LINK_FLAGS} -o $@
+
+${AUTO}/scheme.tlo: ${AUTO}/scheme.tl ${EXE}/tl-parser
+	${EXE}/tl-parser -e $@ ${AUTO}/scheme.tl
+
+${AUTO}/scheme.tl: ${srcdir}/scheme$(SCHEME_VERSION).tl ${srcdir}/encrypted_scheme$(ENCRYPTED_SCHEME_VERSION).tl ${srcdir}/binlog.tl ${srcdir}/mtproto.tl ${srcdir}/append.tl | ${AUTO}
+	cat $^ > $@
+
+${AUTO}/scheme2.tl: ${AUTO}/scheme.tl ${EXE}/tl-parser
+	${EXE}/tl-parser -E ${AUTO}/scheme.tl 2> $@  || ( cat $@ && rm $@ && false )
+
+${AUTO}/auto.c: ${AUTO}/scheme.tlo ${EXE}/generate
+	${EXE}/generate ${AUTO}/scheme.tlo > $@
+
+${AUTO}/auto-%.c: ${AUTO}/scheme.tlo ${EXE}/generate auto/constants.h ${AUTO}/auto-%.h | create_dirs_and_headers
+	${EXE}/generate -g $(patsubst ${AUTO}/auto-%.c,%,$@) ${AUTO}/scheme.tlo > $@ || ( rm $@ && false )
+
+${AUTO}/auto-%.h: ${AUTO}/scheme.tlo ${EXE}/generate
+	${EXE}/generate -g $(patsubst ${AUTO}/auto-%.h,%-header,$@) ${AUTO}/scheme.tlo > $@ || ( rm $@ && false )
+
+
+${AUTO}/constants.h: ${AUTO}/scheme2.tl ${srcdir}/gen_constants_h.awk
+	awk -f ${srcdir}/gen_constants_h.awk < $< > $@
+
+${EXE}/dump-tl-file: ${OBJ}/auto/auto.o ${TLD_OBJECTS}
+	${CC} ${OBJ}/auto/auto.o ${TLD_OBJECTS} ${LINK_FLAGS} -o $@
+
+clean:
+	rm -rf ${DIR_LIST}
+

--- a/config.h.mingw
+++ b/config.h.mingw
@@ -1,0 +1,101 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define the gettext package to be used */
+#define GETTEXT_PACKAGE "telegram-purple"
+
+#define ENABLE_NLS 1
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+/* #undef HAVE_ARPA_INET_H */
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `gcrypt' library (-lgcrypt). */
+#define HAVE_LIBGCRYPT 1
+
+/* Define to 1 if you have the `rt' library (-lrt). */
+/* #undef HAVE_LIBRT */
+
+/* Define to 1 if you have the `webp' library (-lwebp). */
+#define HAVE_LIBWEBP 1
+
+/* Define to 1 if you have `z' library (-lz) */
+#define HAVE_LIBZ 1
+
+/* Define to 1 if your system has a GNU libc compatible `malloc' function, and
+   to 0 otherwise. */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `memset' function. */
+#define HAVE_MEMSET 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+/* #undef HAVE_NETDB_H */
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+/* #undef HAVE_NETINET_IN_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+/* #undef HAVE_SYS_SOCKET_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "telegram-purple"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "telegram-purple 1.2.2"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "telegram-purple"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.2.2"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Define to rpl_malloc if the replacement function should be used. */
+/* #undef malloc */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */

--- a/config.h.mingw
+++ b/config.h.mingw
@@ -80,16 +80,13 @@
 #define PACKAGE_NAME "telegram-purple"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "telegram-purple 1.2.2"
+#define PACKAGE_STRING PACKAGE_NAME " " PACKAGE_VERSION
 
 /* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "telegram-purple"
+#define PACKAGE_TARNAME PACKAGE_NAME
 
 /* Define to the home page for this package. */
 #define PACKAGE_URL ""
-
-/* Define to the version of this package. */
-#define PACKAGE_VERSION "1.2.2"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1

--- a/config.h.tgl.mingw
+++ b/config.h.tgl.mingw
@@ -1,0 +1,167 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* disable extf queries */
+/* #undef DISABLE_EXTF */
+
+/* Use libevent v1 */
+/* #undef EVENT_V1 */
+
+/* Use libevent v2 */
+/* #undef EVENT_V2 */
+
+/* Define to 1 if you have the `alarm' function. */
+#define HAVE_ALARM 1
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+/* #undef HAVE_ARPA_INET_H */
+
+/* Define to 1 if you have the `endpwent' function. */
+/* #undef HAVE_ENDPWENT */
+
+/* Define to 1 if you have the <execinfo.h> header file. */
+/* #undef HAVE_EXECINFO_H */
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `event' library (-levent). */
+/* #undef HAVE_LIBEVENT */
+
+/* Define to 1 if you have the `gcrypt' library (-lgcrypt). */
+#define HAVE_LIBGCRYPT 1
+
+/* Define to 1 if you have `z' library (-lz) */
+#define HAVE_LIBZ 1
+
+/* Define to 1 if you have the <mach/mach.h> header file. */
+/* #undef HAVE_MACH_MACH_H */
+
+/* Define to 1 if your system has a GNU libc compatible `malloc' function, and
+   to 0 otherwise. */
+#define HAVE_MALLOC 1
+
+/* Define to 1 if you have the <malloc.h> header file. */
+#define HAVE_MALLOC_H 1
+
+/* Define to 1 if you have the `memmove' function. */
+#define HAVE_MEMMOVE 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `memset' function. */
+#define HAVE_MEMSET 1
+
+/* Define to 1 if you have the `mkdir' function. */
+#define HAVE_MKDIR 1
+
+/* Define to 1 if you have the <netdb.h> header file. */
+/* #undef HAVE_NETDB_H */
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+/* #undef HAVE_NETINET_IN_H */
+
+/* Define to 1 if your system has a GNU libc compatible `realloc' function,
+   and to 0 otherwise. */
+#define HAVE_REALLOC 1
+
+/* Define to 1 if you have the `select' function. */
+/* #undef HAVE_SELECT */
+
+/* Define to 1 if you have the `socket' function. */
+/* #undef HAVE_SOCKET */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strndup' function. */
+/* #undef HAVE_STRNDUP */
+
+/* Define to 1 if you have the <sys/file.h> header file. */
+#define HAVE_SYS_FILE_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+/* #undef HAVE_SYS_SOCKET_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <termios.h> header file. */
+/* #undef HAVE_TERMIOS_H */
+
+/* Define to 1 if you have the `uname' function. */
+/* #undef HAVE_UNAME */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if the system has the `__builtin_bswap32' built-in function */
+#define HAVE___BUILTIN_BSWAP32 1
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "telegram-cli"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "telegram-cli 1.0"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "telegram-cli"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.0"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* avoid OpenSSL entirely, use libgcrypt instead (this can't read *.pub files,
+   though.) */
+#define TGL_AVOID_OPENSSL 1
+
+/* fixed for correct valgrind work */
+/* #undef VALGRIND_FIXES */
+
+/* Define to `int' if <sys/types.h> doesn't define. */
+#define gid_t int
+
+/* Define to `__inline__' or `__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define to rpl_malloc if the replacement function should be used. */
+/* #undef malloc */
+
+/* Define to rpl_realloc if the replacement function should be used. */
+/* #undef realloc */
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */
+
+/* Define to `int' if <sys/types.h> doesn't define. */
+#define uid_t int

--- a/telegram-base.c
+++ b/telegram-base.c
@@ -114,7 +114,7 @@ void read_state_file (struct tgl_state *TLS) {
   char *name = 0;
   name = g_strdup_printf("%s/%s", TLS->base_path, "state");
 
-  int state_file_fd = open (name, O_CREAT | O_RDWR, 0600);
+  int state_file_fd = open (name, O_CREAT | O_RDWR | O_BINARY, 0600);
   free (name);
 
   if (state_file_fd < 0) {
@@ -150,7 +150,7 @@ void write_state_file (struct tgl_state *TLS) {
   char *name = 0;
   name = g_strdup_printf("%s/%s", TLS->base_path, "state");
 
-  int state_file_fd = open (name, O_CREAT | O_RDWR, 0600);
+  int state_file_fd = open (name, O_CREAT | O_RDWR | O_BINARY, 0600);
   free (name);
 
   if (state_file_fd < 0) {
@@ -209,7 +209,7 @@ void write_dc (struct tgl_dc *DC, void *extra) {
 void write_auth_file (struct tgl_state *TLS) {
   char *name = 0;
   name = g_strdup_printf("%s/%s", TLS->base_path, "auth");
-  int auth_file_fd = open (name, O_CREAT | O_RDWR, 0600);
+  int auth_file_fd = open (name, O_CREAT | O_RDWR | O_BINARY, 0600);
   free (name);
   if (auth_file_fd < 0) { return; }
   int x = DC_SERIALIZED_MAGIC;
@@ -274,7 +274,7 @@ void empty_auth_file (struct tgl_state *TLS) {
 void read_auth_file (struct tgl_state *TLS) {
   char *name = 0;
   name = g_strdup_printf("%s/%s", TLS->base_path, "auth");
-  int auth_file_fd = open (name, O_CREAT | O_RDWR, 0600);
+  int auth_file_fd = open (name, O_CREAT | O_RDWR | O_BINARY, 0600);
   free (name);
   if (auth_file_fd < 0) {
     empty_auth_file (TLS);
@@ -345,7 +345,7 @@ void write_secret_chat (tgl_peer_t *_P, void *extra) {
 void write_secret_chat_file (struct tgl_state *TLS) {
   char *name = 0;
   name = g_strdup_printf("%s/%s", TLS->base_path, "secret");
-  int secret_chat_fd = open (name, O_CREAT | O_RDWR, 0600);
+  int secret_chat_fd = open (name, O_CREAT | O_RDWR | O_BINARY, 0600);
   free (name);
   assert (secret_chat_fd >= 0);
   int x = SECRET_CHAT_FILE_MAGIC;

--- a/telegram-base.c
+++ b/telegram-base.c
@@ -95,7 +95,9 @@ int read_pubkey_file (const char *name, struct rsa_pubkey *dst) {
     return 0;
   }
 
-  if (n_len != read (pubkey_fd, n_raw, n_len)) {
+  gint readret;
+  readret = read (pubkey_fd, n_raw, n_len);
+  if (readret <= 0 || (n_len != (guint) readret)) {
     free (n_raw);
     close (pubkey_fd);
     return 0;
@@ -110,9 +112,7 @@ int read_pubkey_file (const char *name, struct rsa_pubkey *dst) {
 
 void read_state_file (struct tgl_state *TLS) {
   char *name = 0;
-  if (asprintf (&name, "%s/%s", TLS->base_path, "state") < 0) {
-    return;
-  }
+  name = g_strdup_printf("%s/%s", TLS->base_path, "state");
 
   int state_file_fd = open (name, O_CREAT | O_RDWR, 0600);
   free (name);
@@ -148,9 +148,7 @@ void write_state_file (struct tgl_state *TLS) {
   wseq = TLS->seq; wpts = TLS->pts; wqts = TLS->qts; wdate = TLS->date;
   
   char *name = 0;
-  if (asprintf (&name, "%s/%s", TLS->base_path, "state") < 0) {
-    return;
-  }
+  name = g_strdup_printf("%s/%s", TLS->base_path, "state");
 
   int state_file_fd = open (name, O_CREAT | O_RDWR, 0600);
   free (name);
@@ -210,9 +208,7 @@ void write_dc (struct tgl_dc *DC, void *extra) {
 
 void write_auth_file (struct tgl_state *TLS) {
   char *name = 0;
-  if (asprintf (&name, "%s/%s", TLS->base_path, "auth") < 0) {
-    return;
-  }
+  name = g_strdup_printf("%s/%s", TLS->base_path, "auth");
   int auth_file_fd = open (name, O_CREAT | O_RDWR, 0600);
   free (name);
   if (auth_file_fd < 0) { return; }
@@ -277,9 +273,7 @@ void empty_auth_file (struct tgl_state *TLS) {
 
 void read_auth_file (struct tgl_state *TLS) {
   char *name = 0;
-  if (asprintf (&name, "%s/%s", TLS->base_path, "auth") < 0) {
-    return;
-  }
+  name = g_strdup_printf("%s/%s", TLS->base_path, "auth");
   int auth_file_fd = open (name, O_CREAT | O_RDWR, 0600);
   free (name);
   if (auth_file_fd < 0) {
@@ -350,9 +344,7 @@ void write_secret_chat (tgl_peer_t *_P, void *extra) {
 
 void write_secret_chat_file (struct tgl_state *TLS) {
   char *name = 0;
-  if (asprintf (&name, "%s/%s", TLS->base_path, "secret") < 0) {
-    return;
-  }
+  name = g_strdup_printf("%s/%s", TLS->base_path, "secret");
   int secret_chat_fd = open (name, O_CREAT | O_RDWR, 0600);
   free (name);
   assert (secret_chat_fd >= 0);
@@ -414,9 +406,7 @@ void read_secret_chat (struct tgl_state *TLS, int fd, int v) {
 
 void read_secret_chat_file (struct tgl_state *TLS) {
   char *name = 0;
-  if (asprintf (&name, "%s/%s", TLS->base_path, "secret") < 0) {
-    return;
-  }
+  name = g_strdup_printf("%s/%s", TLS->base_path, "secret");
   
   int secret_chat_fd = open (name, O_RDWR, 0600);
   free (name);

--- a/telegram-base.c
+++ b/telegram-base.c
@@ -76,7 +76,7 @@ int read_pubkey_file (const char *name, struct rsa_pubkey *dst) {
   dst->n_len = 0;
   dst->n_raw = NULL;
 
-  int pubkey_fd = open (name, O_RDONLY);
+  int pubkey_fd = open (name, O_RDONLY | O_BINARY);
   if (pubkey_fd < 0) {
     return 0;
   }
@@ -408,7 +408,7 @@ void read_secret_chat_file (struct tgl_state *TLS) {
   char *name = 0;
   name = g_strdup_printf("%s/%s", TLS->base_path, "secret");
   
-  int secret_chat_fd = open (name, O_RDWR, 0600);
+  int secret_chat_fd = open (name, O_RDWR | O_BINARY, 0600);
   free (name);
   
   if (secret_chat_fd < 0) { return; }

--- a/telegram-purple.c
+++ b/telegram-purple.c
@@ -29,8 +29,10 @@
 #include <assert.h>
 #include <unistd.h>
 #include <sys/types.h>
+#ifndef WIN32
 #include <pwd.h>
 #include <regex.h>
+#endif
 
 #include "accountopt.h"
 #include "blist.h"
@@ -47,6 +49,9 @@
 #include "util.h"
 #include "eventloop.h"
 #include "request.h"
+#ifdef WIN32
+#include "win32/win32dep.h"
+#endif
 
 #include <tgl.h>
 #include <tgl-binlog.h>
@@ -80,7 +85,11 @@ static void on_user_get_info (struct tgl_state *TLS, void *info_data, int succes
 
 const char *config_dir = "telegram-purple";
 const char *user_pk_filename = "server.tglpub";
+#ifdef WIN32
+const char *pk_path = "server.tglpub";
+#else
 const char *pk_path = "/etc/telegram-purple/server.tglpub";
+#endif
 
 struct tgl_update_callback tgp_callback = {
   .logprintf = debug,
@@ -574,8 +583,14 @@ static void tgprpl_login (PurpleAccount * acct) {
   debug ("base configuration path: '%s'", TLS->base_path);
   
   struct rsa_pubkey pubkey;
-  debug ("trying global pubkey at %s", pk_path);
-  gboolean global_pk_loaded = read_pubkey_file (pk_path, &pubkey);
+#ifdef WIN32
+  gchar *global_pk_path = g_strdup_printf("%s/%s", DATADIR, pk_path);
+#else
+  gchar *global_pk_path = g_strdup(pk_path);
+#endif
+  debug ("trying global pubkey at %s", global_pk_path);
+  gboolean global_pk_loaded = read_pubkey_file (global_pk_path, &pubkey);
+  g_free(global_pk_path);
 
   tgl_set_verbosity (TLS, 4);
   if (global_pk_loaded) {
@@ -607,7 +622,7 @@ static void tgprpl_login (PurpleAccount * acct) {
       return;
     }
   }
-
+  
   tgl_set_ev_base (TLS, conn);
   tgl_set_net_methods (TLS, &tgp_conn_methods);
   tgl_set_timer_methods (TLS, &tgp_timers);

--- a/telegram-purple.c
+++ b/telegram-purple.c
@@ -623,6 +623,7 @@ static void tgprpl_login (PurpleAccount * acct) {
     }
   }
   
+  tgl_enable_pfs (TLS);
   tgl_set_ev_base (TLS, conn);
   tgl_set_net_methods (TLS, &tgp_conn_methods);
   tgl_set_timer_methods (TLS, &tgp_timers);

--- a/telegram-purple.nsi
+++ b/telegram-purple.nsi
@@ -1,0 +1,107 @@
+; Script based on the Skype4Pidgin and Off-the-Record Messaging NSI files
+
+
+SetCompress off
+
+; todo: SetBrandingImage
+; HM NIS Edit Wizard helper defines
+!define PRODUCT_NAME "telegram-purple"
+!define PRODUCT_VERSION "${PLUGIN_VERSION}"
+!define PRODUCT_PUBLISHER "The telegram-purple team"
+!define PRODUCT_WEB_SITE "https://github.com/majn/telegram-purple"
+!define PRODUCT_UNINST_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}"
+!define PRODUCT_UNINST_ROOT_KEY "HKLM"
+
+; MUI 1.67 compatible ------
+!include "MUI.nsh"
+
+; MUI Settings
+!define MUI_ABORTWARNING
+!define MUI_ICON "${NSISDIR}\Contrib\Graphics\Icons\modern-install.ico"
+!define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall.ico"
+
+; Welcome page
+!insertmacro MUI_PAGE_WELCOME
+; License page
+!insertmacro MUI_PAGE_LICENSE "COPYING"
+; Instfiles page
+!insertmacro MUI_PAGE_INSTFILES
+!define MUI_FINISHPAGE_RUN
+!define MUI_FINISHPAGE_RUN_TEXT "Run Pidgin"
+!define MUI_FINISHPAGE_RUN_FUNCTION "RunPidgin"
+!insertmacro MUI_PAGE_FINISH
+
+; Uninstaller pages
+;!insertmacro MUI_UNPAGE_INSTFILES
+
+; Language files
+!insertmacro MUI_LANGUAGE "English"
+
+; MUI end ------
+
+Name "${PRODUCT_NAME} ${PRODUCT_VERSION}"
+OutFile "${PRODUCT_NAME}-${PRODUCT_VERSION}.exe"
+
+Var "PidginDir"
+
+ShowInstDetails show
+ShowUnInstDetails show
+
+Section "MainSection" SEC01
+    ;Check for pidgin installation
+    Call GetPidginInstPath
+    
+    SetOverwrite try
+    
+	SetOutPath "$PidginDir\pixmaps\pidgin"
+	File "/oname=protocols\16\telegram.png" "imgs\telegram16.png"
+	File "/oname=protocols\22\telegram.png" "imgs\telegram22.png"
+	File "/oname=protocols\48\telegram.png" "imgs\telegram48.png"
+
+    SetOverwrite try
+	copy:
+		ClearErrors
+		Delete "$PidginDir\plugins\${PRPL_NAME}"
+		IfErrors dllbusy
+		SetOutPath "$PidginDir\plugins"
+	    File "bin\${PRPL_NAME}"
+		Goto after_copy
+	dllbusy:
+		MessageBox MB_RETRYCANCEL "${PRPL_NAME} is busy. Please close Pidgin (including tray icon) and try again" IDCANCEL cancel
+		Goto copy
+	cancel:
+		Abort "Installation of telegram-purple aborted"
+	after_copy:
+	
+	SetOutPath "$PidginDir\locale"
+	File /nonfatal "/oname=de\LC_MESSAGES\telegram-purple.mo" "po\de.mo"
+	File /nonfatal "/oname=es_AR\LC_MESSAGES\telegram-purple.mo" "po\es_AR.mo"
+	File /nonfatal "/oname=pl\LC_MESSAGES\telegram-purple.mo" "po\pl.mo"
+	File /nonfatal "/oname=ru\LC_MESSAGES\telegram-purple.mo" "po\ru.mo"
+	File /nonfatal "/oname=sq\LC_MESSAGES\telegram-purple.mo" "po\sq.mo"
+	
+	SetOutPath "$PidginDir"
+	File "/oname=server.tglpub" "tg-server.tglpub"
+	File "${WIN32_DEV_TOP}\libgpg-error-1.12-2\bin\libgpg-error-0.dll"
+	File "${WIN32_DEV_TOP}\libgcrypt-1.6.3\bin\libgcrypt-20.dll"
+	File "${WIN32_DEV_TOP}\libwebp-0.4.3-1\bin\libwebp-5.dll"
+	File "${WIN32_DEV_TOP}\mingw\bin\libgcc_s_sjlj-1.dll"
+	
+SectionEnd
+
+Function GetPidginInstPath
+  Push $0
+  ReadRegStr $0 HKLM "Software\pidgin" ""
+	IfFileExists "$0\pidgin.exe" cont
+	ReadRegStr $0 HKCU "Software\pidgin" ""
+	IfFileExists "$0\pidgin.exe" cont
+		MessageBox MB_OK|MB_ICONINFORMATION "Failed to find Pidgin installation."
+		Abort "Failed to find Pidgin installation. Please install Pidgin first."
+  cont:
+	StrCpy $PidginDir $0
+FunctionEnd
+
+Function RunPidgin
+	ExecShell "" "$PidginDir\pidgin.exe"
+FunctionEnd
+

--- a/tgp-ft.c
+++ b/tgp-ft.c
@@ -63,7 +63,7 @@ static char *tgp_strdup_determine_filename (const char *mime, const char *captio
       type = "bin";
     }
   }
-  return g_strdup_printf ("%lld.%s", ABS(hash), type);
+  return g_strdup_printf ("%" G_GINT64_MODIFIER "d.%s", ABS(hash), type);
 }
 
 static void tgprpl_xfer_recv_on_finished (struct tgl_state *TLS, void *_data, int success, const char *filename) {

--- a/tgp-msg.c
+++ b/tgp-msg.c
@@ -27,6 +27,25 @@
 #include <locale.h>
 #include <tgl-queries.h>
 
+#if !GLIB_CHECK_VERSION(2,30,0)
+gchar *
+g_utf8_substring (const gchar *str,
+                  glong        start_pos,
+                  glong        end_pos)
+{
+  gchar *start, *end, *out;
+
+  start = g_utf8_offset_to_pointer (str, start_pos);
+  end = g_utf8_offset_to_pointer (start, end_pos - start_pos);
+
+  out = g_malloc (end - start + 1);
+  memcpy (out, start, end - start);
+  out[end - start] = 0;
+
+  return out;
+}
+#endif
+
 #include "telegram-base.h"
 #include "tgp-structs.h"
 #include "tgp-msg.h"

--- a/tgp-net.c
+++ b/tgp-net.c
@@ -392,7 +392,7 @@ static void try_write (struct connection *c) {
   // debug ("try write: fd = %d\n", c->fd);
   int x = 0;
   while (c->out_head) {
-    int r = write (c->fd, c->out_head->rptr, c->out_head->wptr - c->out_head->rptr);
+    int r = send (c->fd, (const char *)c->out_head->rptr, c->out_head->wptr - c->out_head->rptr, 0);
     if (r >= 0) {
       x += r;
       c->out_head->rptr += r;
@@ -468,7 +468,7 @@ static void try_read (struct connection *c) {
   #endif
   int x = 0;
   while (1) {
-    int r = read (c->fd, c->in_tail->wptr, c->in_tail->end - c->in_tail->wptr);
+    int r = recv (c->fd, (char *)c->in_tail->wptr, c->in_tail->end - c->in_tail->wptr, 0);
     if (r > 0) {
       c->last_receive_time = tglt_get_double_time ();
       stop_ping_timer (c);

--- a/tgp-net.c
+++ b/tgp-net.c
@@ -23,16 +23,20 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <sys/types.h>
+#ifndef WIN32
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <sys/fcntl.h>
 #include <sys/socket.h>
+#include <poll.h>
+#include <arpa/inet.h>
+#else
+#include <winsock2.h>
+#endif
+#include <sys/fcntl.h>
 #include <errno.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <poll.h>
-#include <arpa/inet.h>
 #include <sys/time.h>
 #include <time.h>
 
@@ -259,7 +263,7 @@ static void net_on_connected (gpointer arg, gint fd, const gchar *error_message)
   
   if (fd == -1) {
     const char *msg = "Connection not possible, either your network or a Telegram data center is down, or the"
-    " Telegram network configuratio has changed.";
+    " Telegram network configuration has changed.";
     warning (msg);
     return;
   }
@@ -403,7 +407,7 @@ static void try_write (struct connection *c) {
       delete_connection_buffer (b);
     } else {
       if (errno != EAGAIN && errno != EWOULDBLOCK) {
-        info ("fail_connection: write_error %m\n");
+        info ("fail_connection: write_error %s\n", g_strerror(errno));
         fail_connection (c);
         return;
       } else {
@@ -481,7 +485,7 @@ static void try_read (struct connection *c) {
       c->in_tail = b;
     } else {
       if (errno != EAGAIN && errno != EWOULDBLOCK) {
-        debug ("fail_connection: read_error %m\n");
+        debug ("fail_connection: read_error %s\n", strerror(errno));
         fail_connection (c);
         return;
       } else {


### PR DESCRIPTION
Windows doesn't have asprintf() so switch with g_strdup_printf()
Stores the server.tglpub file in the Pidgin root directory
Replaces the gnu-libc specific %m printf parameter
Provides a g_utf8_substring() function, since Pidgin on Windows is compiled with glib 2.28