### PR TITLE
timer_alarm: Set fd to -1 to avoid warnings on tgl_timer_delete

### DIFF
--- a/tgp-timers.c
+++ b/tgp-timers.c
@@ -31,6 +31,7 @@ struct tgl_timer {
 
 static int timer_alarm (gpointer arg) {
   struct tgl_timer *t = arg;
+  t->fd = -1;
   t->cb (t->TLS, t->arg);
   return FALSE;
 }


### PR DESCRIPTION
Warnings like this:

    GLib-CRITICAL **: Source ID N was not found when attempting to remove it

----

Applies against dev-1.2.3. I hope that's the branch i'm supposed to submit patches against.