### PR TITLE
Remove the need for gcrypt in telegram-purple

### DIFF
--- a/telegram-base.c
+++ b/telegram-base.c
@@ -380,10 +380,10 @@ void read_secret_chat (struct tgl_state *TLS, int fd, int v) {
     assert (read (fd, sha, 20) == 20);
   } else {
     PurpleCipher *sha1_cipher = purple_ciphers_find_cipher("sha1");
-  	PurpleCipherContext *sha1_ctx = purple_cipher_context_new(sha1_cipher, NULL);
-  	purple_cipher_context_append(sha1_ctx, key, 256);
-  	purple_cipher_context_digest(sha1_ctx, 20, sha, NULL);
-  	purple_cipher_context_destroy(sha1_ctx);
+    PurpleCipherContext *sha1_ctx = purple_cipher_context_new(sha1_cipher, NULL);
+    purple_cipher_context_append(sha1_ctx, key, 256);
+    purple_cipher_context_digest(sha1_ctx, 20, sha, NULL);
+    purple_cipher_context_destroy(sha1_ctx);
   }
   int in_seq_no = 0, out_seq_no = 0, last_in_seq_no = 0;
   if (v >= 1) {

--- a/telegram-base.c
+++ b/telegram-base.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <gcrypt.h>
+#include <cipher.h>
 
 #include "telegram-base.h"
 
@@ -379,7 +379,11 @@ void read_secret_chat (struct tgl_state *TLS, int fd, int v) {
   if (v >= 2) {
     assert (read (fd, sha, 20) == 20);
   } else {
-    gcry_md_hash_buffer (GCRY_MD_SHA1, sha, (void *)key, 256);
+    PurpleCipher *sha1_cipher = purple_ciphers_find_cipher("sha1");
+  	PurpleCipherContext *sha1_ctx = purple_cipher_context_new(sha1_cipher, NULL);
+  	purple_cipher_context_append(sha1_ctx, key, 256);
+  	purple_cipher_context_digest(sha1_ctx, 20, sha, NULL);
+  	purple_cipher_context_destroy(sha1_ctx);
   }
   int in_seq_no = 0, out_seq_no = 0, last_in_seq_no = 0;
   if (v >= 1) {


### PR DESCRIPTION
Use libpurple's own SHA1 implementation