### PR TITLE
Portability fix for POSIX shells

### DIFF
--- a/configure
+++ b/configure
@@ -4414,7 +4414,7 @@ if test "${enable_icons+set}" = set; then :
   enableval=$enable_icons;
 fi
 
-  if test "x$enable_icons" == "xno"; then :
+  if test "x$enable_icons" = "xno"; then :
 
     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Icons are deactivated. Pidgin needs icons. Finch and telepathy-haze don't." >&5
 $as_echo "$as_me: WARNING: Icons are deactivated. Pidgin needs icons. Finch and telepathy-haze don't." >&2;}

--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ AS_IF([test "x$enable_libwebp" != "xno"], [
 AC_SUBST([COPY_ICONS], [yes])
 AC_ARG_ENABLE([icons],
   AS_HELP_STRING([--disable-icons], [Don't copy the protocol icons for Pidgin. Only useful if you're using Finch of telepathy-haze. (Adium users shouldn't be using this build system at all.)]))
-  AS_IF([test "x$enable_icons" == "xno"], [
+  AS_IF([test "x$enable_icons" = "xno"], [
     AC_WARN([Icons are deactivated. Pidgin needs icons. Finch and telepathy-haze don't.])
     AC_SUBST([COPY_ICONS], [no])
   ])


### PR DESCRIPTION
Only a handful of shells support the "==" comparison operator for
the "test" built-in. The standard, portable operator is "=" instead.