### PR TITLE
README.md: add submodule update in Debian package build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ If you just need a `.deb`, simply do:
 
     sudo apt-get install debhelper
     git checkout debian-master
+    git submodule update --recursive
     fakeroot ./debian/rules binary
 
 And you're done! The `.deb` is in the directory at which you started.


### PR DESCRIPTION
Following instructions for building Debian package the process failed with the following error:

```
tgp-msg.c: In function ‘format_service_msg’:
tgp-msg.c:84:10: error: ‘tgl_message_action_chat_add_user’ undeclared (first use in this function)
     case tgl_message_action_chat_add_user: {
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

A solution is to issue a
`git submodule update --recursive`
after the checkout of the `debian-master` branch.
I inserted this line in the README.md file.