### PR TITLE
Compile tgp-info on Windows

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -41,7 +41,7 @@ LIB=libs
 DIR_LIST=${DEP} ${EXE} ${OBJ} ${LIB} ${DEP}/lodepng ${OBJ}/lodepng
 
 PLUGIN_OBJECTS=${OBJ}/tgp-net.o ${OBJ}/tgp-timers.o ${OBJ}/msglog.o ${OBJ}/telegram-base.o ${OBJ}/telegram-purple.o ${OBJ}/tgp-2prpl.o ${OBJ}/tgp-structs.o ${OBJ}/tgp-utils.o ${OBJ}/tgp-chat.o ${OBJ}/tgp-ft.o ${OBJ}/tgp-msg.o ${OBJ}/tgp-request.o ${OBJ}/tgp-blist.o ${OBJ}/lodepng/lodepng.o
-ALL_OBJS=${PLUGIN_OBJECTS}
+ALL_OBJS=${PLUGIN_OBJECTS} ${OBJ}/tgp-info.o
 
 LOCALES=$(patsubst %.po, %.mo, $(wildcard po/*.po))
 


### PR DESCRIPTION
tgp-info was added into the plugin for v1.3.0 but the Makefile.mingw wasn't updated at that stage
