### PR TITLE
Automated RPM and Debian packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: required
+language: C
+
+services:
+  - docker
+
+cache:
+    directories:
+      - $HOME/.cache
+
+env:
+    matrix:
+      - OS=fedora DIST=24
+      - OS=fedora DIST=25
+      - OS=ubuntu DIST=trusty
+      - OS=ubuntu DIST=xenial
+      - OS=ubuntu DIST=yakkety
+      - OS=debian DIST=jessie
+      - OS=debian DIST=stretch
+      - OS=debian DIST=sid
+
+matrix:
+    allow_failures:
+#      - env: OS=fedora DIST=24
+#      - env: OS=fedora DIST=25
+#      - env: OS=ubuntu DIST=trusty
+#      - env: OS=ubuntu DIST=xenial
+#      - env: OS=ubuntu DIST=yakkety
+#      - env: OS=debian DIST=jessie
+#      - env: OS=debian DIST=stretch
+      - env: OS=debian DIST=sid
+
+
+script:
+  - git clone https://github.com/packpack/packpack.git packpack
+  # Split v1.2.4-30-g924e59b into VERSION=1.2.4 RELEASE=30
+  - export VERSION=$(git describe --long --always --tags | sed -n 's/^v\([0-9\.]*\)-\([0-9]*\)-\([a-z0-9]*\)/\1/p')
+  - export RELEASE=$(git describe --long --always --tags | sed -n 's/^v\([0-9\.]*\)-\([0-9]*\)-\([a-z0-9]*\)/\2/p')
+  - packpack/packpack

--- a/rpm/purple-telegram.spec
+++ b/rpm/purple-telegram.spec
@@ -32,6 +32,7 @@ chmod 755 %{buildroot}/%{_libdir}/purple-2/telegram-purple.so
 %{_datadir}/pixmaps/pidgin/protocols/16/telegram.png
 %{_datadir}/pixmaps/pidgin/protocols/22/telegram.png
 %{_datadir}/pixmaps/pidgin/protocols/48/telegram.png
+%{_datadir}/appdata/telegram-purple.metainfo.xml
 
 %changelog
 * Thu Dec 10 2015 mjentsch 1.2.4-1


### PR DESCRIPTION
Hi!

This patch adds support for automated RPM/DEB packages using PackPack [[1]] tool. Now you can have ready-to-use packages for every git commit without need to bump versions in `debian/control` and `rpm/purple-telegram.spec` files. Proposed `.travis.yml` automatically bumps versions, creates a source tarball and builds packages on every commit [[2]]. It is also possible to deploy these packages to [packagecloud.io](https://packagecloud.io) or Amazon S3 using Travis CI. See more examples in [[3]].

This commit is based against debian-master branch, because it requires `debian/` directory for Debian packages.

[1]: https://github.com/packpack/packpack#packpack
[2]: https://travis-ci.org/rtsisyk/telegram-purple/builds/204933482
[3]: https://github.com/tarantool/tarantool-c/blob/master/.travis.yml#L87


