### PR TITLE
Make builds work without .git and commit.h

### DIFF
--- a/commit.h.gen
+++ b/commit.h.gen
@@ -27,8 +27,11 @@ then
     echo "No git available. Assuming everything is up-to-date."
     exit 0
   else
-    echo >&2 "No git available. Can't reconstruct commit.h"
-    exit 1
+    echo >&2 "No git available. Commit info will be missing in build!"
+    echo "#ifndef GIT_COMMIT" > commit.h
+    echo "#  define GIT_COMMIT \"Unknown revision\"" >> commit.h
+    echo "#endif" >> commit.h
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
Untested but should solve the issue @khurshid-alam has in issue #455 

Why such drama for such a small change?