### PR TITLE
Make tgl's configure script respect CC and PKG_CONFIG

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -115,7 +115,7 @@ tgl/Makefile.in:
 	@echo "tgl/Makefile.in not found. Maybe you need to 'git submodule update --init --recursive' ?" && exit 1
 
 tgl/Makefile: tgl/Makefile.in Makefile
-	cd tgl && ./configure -q ${CRYPTO_FLAG} --disable-extf CFLAGS="@CFLAGS@" LDFLAGS="@LDFLAGS@"
+	cd tgl && ./configure ${CRYPTO_FLAG} --disable-extf CFLAGS="@CFLAGS@" LDFLAGS="@LDFLAGS@" CC="@CC@" PKG_CONFIG="@PKG_CONFIG@"
 
 tgl/libs/libtgl.a: tgl/Makefile
 	+${MAKE} -C tgl libs/libtgl.a


### PR DESCRIPTION
It is needed for cross-compiling.
Also remove '-q' to make bug reports more useful.