### PR TITLE
Added script to build version-independent versions of libgpg-error and libgcrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,30 +227,24 @@ Compiling with XCode is a little bit problematic, since it requires you to compi
 1. Get the Adium source, compile it with XCode and copy the build output into telegram-adium/Frameworks/Adium. It should contain at least Adium.framework, AdiumLibpurple.framework and AIUitilies.framework
 2. Open the Adium source code, go to ./Frameworks and copy libglib.framework and libpurple.framework into telegram-adium/Frameworks/Adium
 3. Build the tgl submodule and delete libtgl.so from libs/ (it should only contain libtgl.a)
-4. Install libpng, libwebp, libgcrypt and gnupg with homebrew:
+4. Install libpng and libwebp with homebrew:
 
        brew install libpng webp
-       brew install libgcrypt libgpg-error
 
-5. If you already downloaded libwebp/libgcrypt in previous builds make sure that the binaries are up-to-date
+5. If libpng or libwebp are already installed make sure they're up to date
 
        brew update
-       brew upgrade libpng webp libgcrypt
+       brew upgrade libpng webp
 
-6. Install with homebrew and move it into the appropriate directory so that XCode can find them. Note that the versions might differ, use the one that is
+6. Move libpng and libwebp into the appropriate directory so Xcode can find them. Note that the versions might differ, use the one that is
 
        mkdir -p ./telegram-adium/Frameworks/Adium
        cp /usr/local/Cellar/libpng/1.6.37/lib/libpng.a ./telegram-adium/Frameworks
        cp /usr/local/Cellar/webp/1.0.3/lib/libwebp.a ./telegram-adium/Frameworks
-       cp /usr/local/Cellar/libgcrypt/1.8.4/lib/libgcrypt.20.dylib ./telegram-adium/Frameworks/Adium
-       cp /usr/local/Cellar/libgpg-error/1.36/lib/libgpg-error.0.dylib ./telegram-adium/Frameworks/Adium
 
-7. Update the paths in the dylibs, to assure that the resulting binary will load them form within the bundle.
+7. Build libgpg-error and libgcrypt using `build_dependencies.sh`
 
-       cd ./telegram-adium/Frameworks/Adium
-       install_name_tool -id "@loader_path/../Resources/libgcrypt.20.dylib" ./libgcrypt.20.dylib
-       install_name_tool -id "@loader_path/../Resources/libgpg-error.0.dylib" ./libgpg-error.0.dylib
-       install_name_tool -change "/usr/local/lib/libgpg-error.0.dylib" "@loader_path/../Resources/libgpg-error.0.dylib" ./libgcrypt.20.dylib
+       sh ./telegram-adium/build_dependencies.sh
 
 7. Build the XCode-Project and execute the created bundle
 

--- a/telegram-adium/build_dependencies.sh
+++ b/telegram-adium/build_dependencies.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+# Build libgpg-error and libgcrypt dependencies for telegram-adium
+
+set -ex
+
+LIBGPG_ERROR_VERSION="1.36"
+LIBGCRYPT_VERSION="1.8.5"
+
+# Start relative to the location of build_dependencies.sh
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+cd "$SCRIPTPATH"
+
+mkdir -p Frameworks/dependencies
+cd Frameworks/dependencies
+
+export CFLAGS="-mmacosx-version-min=10.11"
+
+if [[ ! -f "libgpg-error-$LIBGPG_ERROR_VERSION.tar.bz2" ]]; then
+    curl -O "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-$LIBGPG_ERROR_VERSION.tar.bz2"
+fi
+
+if [[ ! -f "libgcrypt-$LIBGCRYPT_VERSION.tar.bz2" ]]; then
+    curl -O "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$LIBGCRYPT_VERSION.tar.bz2"
+fi
+
+tar -xjf "libgpg-error-$LIBGPG_ERROR_VERSION.tar.bz2"
+tar -xjf "libgcrypt-$LIBGCRYPT_VERSION.tar.bz2"
+
+# Build libgpg-error
+pushd "libgpg-error-$LIBGPG_ERROR_VERSION"
+./configure --disable-dependency-tracking --disable-silent-rules --prefix="$(pwd)/../libgpg-error-install"
+make install -j9
+popd
+
+# Build libgcrypt
+pushd "libgcrypt-$LIBGCRYPT_VERSION"
+./configure --disable-dependency-tracking --disable-silent-rules --disable-asm --disable-jent-support --with-libgpg-error-prefix="$(pwd)/../libgpg-error-install" --prefix="$(pwd)/../libgcrypt-install"
+make install -j9
+popd
+
+# Copy libraries into correct location and set loader paths
+mkdir -p ../Adium
+cp libgpg-error-install/lib/libgpg-error.0.dylib ../Adium
+cp libgcrypt-install/lib/libgcrypt.20.dylib ../Adium
+
+install_name_tool -id "@loader_path/../Resources/libgpg-error.0.dylib" ../Adium/libgpg-error.0.dylib
+install_name_tool -id "@loader_path/../Resources/libgcrypt.20.dylib" ../Adium/libgcrypt.20.dylib
+install_name_tool -change "$(pwd)/libgpg-error-$LIBGPG_ERROR_VERSION/../libgpg-error-install/lib/libgpg-error.0.dylib" "@loader_path/../Resources/libgpg-error.0.dylib" ../Adium/libgcrypt.20.dylib
+

--- a/telegram-adium/telegram-adium.xcodeproj/project.pbxproj
+++ b/telegram-adium/telegram-adium.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C410949419BB2D7D0083BF3F /* Build configuration list for PBXNativeTarget "telegram-adium" */;
 			buildPhases = (
+				37D720A9235D37DE001499AF /* Update commit.h */,
 				C410948219BB2D7D0083BF3F /* Sources */,
 				C410948319BB2D7D0083BF3F /* Frameworks */,
 				C410948419BB2D7D0083BF3F /* Resources */,
@@ -350,6 +351,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		37D720A9235D37DE001499AF /* Update commit.h */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Update commit.h";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/../commit.h",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"$SRCROOT\"/..\nmake commit.h\n";
+			showEnvVarsInLog = 0;
+		};
 		C4C325A11C91BD230020D32E /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/telegram-adium/telegram-adium.xcodeproj/project.pbxproj
+++ b/telegram-adium/telegram-adium.xcodeproj/project.pbxproj
@@ -492,8 +492,6 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(HOME)/Library/Application Support/Adium 2.0/PlugIns/";
-				DEPLOYMENT_LOCATION = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -531,8 +529,6 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(HOME)/Library/Application Support/Adium 2.0/PlugIns/";
-				DEPLOYMENT_LOCATION = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Added a build script to build versions of libgpg-error and libgcrypt that target 10.11. Also updated the readme with slightly simpler instructions.

Shouldn't conflict with #520.