### PR TITLE
tgp-ft: Fix use-after-free for immediately-completed transfers

### DIFF
--- a/tgp-ft.c
+++ b/tgp-ft.c
@@ -190,6 +190,13 @@ static void tgprpl_xfer_recv_init (PurpleXfer *X) {
   P = tgp_blist_lookup_peer_get (TLS, who);
   g_return_if_fail(P);
 
+  // Prevent the xfer data from getting freed after cancelling to allow the file transfer to complete
+  // without crashing. This is necessary cause loading the file in libtgl cannot be aborted once started.
+  purple_xfer_ref (X);
+
+  data->timer = purple_timeout_add (100, tgprpl_xfer_upload_progress, X);
+  data->loading = TRUE;
+
   switch (M->media.type) {
     case tgl_message_media_document:
       tgl_do_load_document (TLS, D, tgprpl_xfer_recv_on_finished, data);
@@ -211,13 +218,6 @@ static void tgprpl_xfer_recv_init (PurpleXfer *X) {
       failure ("Unknown message media type: %d, XFER not possible.", M->media.type);
       return;
   }
-
-  // Prevent the xfer data from getting freed after cancelling to allow the file transfer to complete
-  // without crashing. This is necessary cause loading the file in libtgl cannot be aborted once started.
-  purple_xfer_ref (X);
-
-  data->timer = purple_timeout_add (100, tgprpl_xfer_upload_progress, X);
-  data->loading = TRUE;
 }
 
 static void tgprpl_xfer_send_init (PurpleXfer *X) {
@@ -250,14 +250,14 @@ static void tgprpl_xfer_send_init (PurpleXfer *X) {
     flags |= TGLMF_POST_AS_CHANNEL;
   }
 
-  tgl_do_send_document (data->conn->TLS, P->id, (char*) localfile, NULL, 0,
-      flags, tgprpl_xfer_send_on_finished, data);
-
   // see comment in tgprpl_xfer_recv_init()
   purple_xfer_ref (X);
 
   data->timer = purple_timeout_add (100, tgprpl_xfer_upload_progress, X);
   data->loading = TRUE;
+
+  tgl_do_send_document (data->conn->TLS, P->id, (char*) localfile, NULL, 0,
+      flags, tgprpl_xfer_send_on_finished, data);
 }
 
 static void tgprpl_xfer_init_data (PurpleXfer *X, connection_data *conn, struct tgl_message *msg) {


### PR DESCRIPTION
See #528 for details.

I haven't observed any crashes with this patch, but I haven't tested file transfer functionality.