### PR TITLE
Use both CFLAGS and LDFLAGS when linking

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -157,7 +157,7 @@ po/%.mo: po/%.po
 	${MSGFMT_PATH} -cf -o $@ $< >/dev/null 2>&1
 
 ${PRPL_LIBNAME}: ${ALL_OBJS} tgl/libs/libtgl.a | create_dirs
-	${CC} -shared -o $@ $^ ${LDFLAGS}
+	${CC} -shared -o $@ $^ ${CFLAGS} ${LDFLAGS}
 
 
 ### == Translation fixes == ###


### PR DESCRIPTION
`CFLAGS` may contain things needed when linking; it’s like this in general:

 - compiling C code: `CPPFLAGS` + `CFLAGS`
 - compiling C++ code: `CPPFLAGS` + `CXXFLAGS`
 - linking with `$CC`: `CFLAGS` + `LDFLAGS`
 - linking with `$CXX`: `CXXFLAGS` + `LDFLAGS`
