### PR TITLE
Add support for clickable HTTP(S) download links

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Download base URI */
+#undef DOWNLOAD_URI_BASE
+
 /* Define the gettext package to be used */
 #undef GETTEXT_PACKAGE
 

--- a/configure
+++ b/configure
@@ -694,6 +694,7 @@ with_openssl
 with_zlib
 enable_libwebp
 enable_libpng
+with_download_base
 enable_icons
 enable_translation
 '
@@ -1347,6 +1348,8 @@ Optional Packages:
   --with-zlib=DIR         root directory path of zlib installation [defaults to
                           /usr/local or /usr if not found in /usr/local]
   --without-zlib          to disable zlib usage completely
+  --with-download-base=URI
+                          Set default base URI for downloads
 
 Some influential environment variables:
   CC          C compiler command
@@ -4567,6 +4570,29 @@ fi
 
 
 fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for download URI base path" >&5
+$as_echo_n "checking for download URI base path... " >&6; }
+
+# Check whether --with-download_base was given.
+if test "${with_download_base+set}" = set; then :
+  withval=$with_download_base; { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${withval}" >&5
+$as_echo "${withval}" >&6; }
+  if test x$withval != xno; then :
+
+
+cat >>confdefs.h <<_ACEOF
+#define DOWNLOAD_URI_BASE "$withval"
+_ACEOF
+
+
+fi
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+
 
 # Check whether --enable-icons was given.
 if test "${enable_icons+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,16 @@ AS_IF([test "x$enable_libpng" != "xno"], [
     AC_CHECK_LIB([png], [png_write_png], [], [AC_MSG_ERROR([no libpng found, try --disable-libpng])])
   ])
 
+AC_MSG_CHECKING([for download URI base path])
+AC_ARG_WITH([download_base],
+  AS_HELP_STRING([--with-download-base=URI], [Set default base URI for downloads]),
+  AC_MSG_RESULT([${withval}])
+  AS_IF([test x$withval != xno], [
+    AC_DEFINE_UNQUOTED([DOWNLOAD_URI_BASE], ["$withval"], [Download base URI])]
+  ),
+  AC_MSG_RESULT([no])
+)
+
 AC_ARG_ENABLE([icons],
   AS_HELP_STRING([--disable-icons], [Unsupported option. Use 'make noicon_install' instead.]))
 AS_IF([test "x$enable_icons" == "xno"], [

--- a/telegram-base.c
+++ b/telegram-base.c
@@ -381,34 +381,26 @@ void read_secret_chat_file (struct tgl_state *TLS) {
   info ("read secret chat file: %d chats read", cnt);
 }
 
-gchar *get_config_dir (char const *username) {
-  gchar *dir = g_strconcat (purple_user_dir(), G_DIR_SEPARATOR_S, config_dir,
-                                G_DIR_SEPARATOR_S, username, NULL);
-  
+gchar *get_config_dir (const char *username) {
+  gchar *dir = g_build_filename (purple_user_dir(), "telegram-purple", username, NULL);
   if (g_str_has_prefix (dir, g_get_tmp_dir())) {
-    // telepathy-haze will set purple user dir to a tmp path,
-    // but we need the files to be persistent
+    // telepathy-haze will set purple user dir to a tmp path, but we need persistence
     g_free (dir);
-    dir = g_strconcat (g_get_home_dir(), G_DIR_SEPARATOR_S, ".telegram-purple",
-                                  G_DIR_SEPARATOR_S, username, NULL);
+    dir = g_build_filename (g_get_home_dir(), ".telegram-purple", username, NULL);
   }
-  g_mkdir_with_parents (dir, 0700);
   return dir;
 }
 
-gchar *get_download_dir (struct tgl_state *TLS) {
-  assert (TLS->base_path);
-  static gchar *dir;
-  if (dir) {
-    g_free (dir);
-  }
-  if (g_strcmp0(purple_core_get_ui(), "BitlBee") == 0) {
-  dir = g_strconcat ("/tmp",  G_DIR_SEPARATOR_S, "downloads", NULL);
-  } else {
-  dir = g_strconcat (TLS->base_path, G_DIR_SEPARATOR_S, "downloads", NULL);
-  }
-  g_mkdir_with_parents (dir, 0700);
-  return dir;
+gchar *get_download_path (struct tgl_state *TLS, const char *filename) {
+  connection_data *conn = tls_get_data (TLS);
+  g_return_val_if_fail (conn != NULL && conn->download_dir != NULL, NULL);
+  return g_build_filename (conn->download_dir, filename, NULL);
+}
+
+gchar *get_download_uri (struct tgl_state *TLS, const char *filename) {
+  connection_data *conn = tls_get_data (TLS);
+  g_return_val_if_fail (conn != NULL && conn->download_dir != NULL, NULL);
+  return g_build_filename (conn->download_uri, filename, NULL);
 }
 
 void write_secret_chat_gw (struct tgl_state *TLS, void *extra, int success, struct tgl_secret_chat *_) {

--- a/telegram-base.h
+++ b/telegram-base.h
@@ -31,8 +31,9 @@ void read_secret_chat_file (struct tgl_state *TLS);
 void write_secret_chat_file (struct tgl_state *TLS);
 void write_secret_chat_gw (struct tgl_state *TLS, void *extra, int success, struct tgl_secret_chat *E);
 
-gchar *get_config_dir (char const *username);
-gchar *get_download_dir (struct tgl_state *TLS);
+gchar *get_config_dir (const char *username);
+gchar *get_download_path (struct tgl_state *TLS, const char *filename);
+gchar *get_download_uri (struct tgl_state *TLS, const char *filename);
 
 int tgp_visualize_key (struct tgl_state *TLS, unsigned char* sha1_key);
 void tgp_create_group_chat_by_usernames (struct tgl_state *TLS, const char *title,

--- a/telegram-purple.h
+++ b/telegram-purple.h
@@ -105,7 +105,6 @@
 
 extern const char *pk_path;
 extern const char *user_pk_filename;
-extern const char *config_dir;
 extern PurplePlugin *_telegram_protocol;
 void import_chat_link (struct tgl_state *TLS, const char *link);
 void export_chat_link_by_name (struct tgl_state *TLS, const char *name);

--- a/tgp-structs.c
+++ b/tgp-structs.c
@@ -127,7 +127,9 @@ void *connection_data_free (connection_data *conn) {
   g_hash_table_destroy (conn->id_to_purple_name);
   g_hash_table_destroy (conn->purple_name_to_id);
   g_hash_table_destroy (conn->channel_members);
-  
+  g_free (conn->download_dir);
+  g_free (conn->download_uri);
+
   tgprpl_xfer_free_all (conn);
   g_free (conn->TLS->base_path);
   tgl_free_all (conn->TLS);

--- a/tgp-structs.h
+++ b/tgp-structs.h
@@ -50,6 +50,8 @@ typedef struct {
   GHashTable *channel_members;
   GList *pending_joins;
   int dialogues_ready;
+  gchar *download_dir;
+  gchar *download_uri;
 } connection_data;
 
 struct tgp_xfer_send_data {


### PR DESCRIPTION
Add a compile-time macro `-DDOWNLOAD_URI_BASE` for specifying a download
URI base path. For example, use `"http://localhost/telegram/"` instead of
the default `"file:///tmp/downloads/"` base path to create clickable HTTP
links for downloads when running bitlbee and HTTP server at localhost.

---

## Before (`DOWNLOAD_URI_BASE` *undefined*)

```sh
$ ./configure
$ make && make install
```

```
20:54 < Avttre> file:///tmp/downloads/download_400089800340_121670.jpg
```

## After (`DOWNLOAD_URI_BASE` *defined*)

```sh
$ ./configure CFLAGS='-DDOWNLOAD_URI_BASE=\""https://huumeet.info/telegram/\""'
$ make && make install
```

``` 
20:54 < Avttre> https://huumeet.info/telegram/download_400089800340_121670.jpg
```