### PR TITLE
Include ppc64le jobs for gcc. Install gettext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_install:
   - git submodule update --init --recursive
   - sudo apt-get update -qq
   - sudo apt-get install -qq libssl-dev libgcrypt20-dev libpurple-dev libwebp-dev
+  - if [ "$TRAVIS_CPU_ARCH" = "ppc64le" ]; then
+    sudo apt-get install -qq gettext;
+    fi
 script:
   - ./configure $CONFIGURE_FLAGS
   - make -j2
@@ -73,3 +76,25 @@ matrix:
 #      env: CONFIGURE_FLAGS="--disable-png                  --disable-libwebp --disable-translation"
 #    - compiler: XXX
 #      env: CONFIGURE_FLAGS="--disable-png --disable-gcrypt --disable-libwebp --disable-translation"
+# Include power jobs for gcc
+  include:
+    - compiler: gcc
+      arch: ppc64le
+      dist: xenial
+      env: CONFIGURE_FLAGS=""
+    - compiler: gcc
+      arch: ppc64le
+      dist: xenial
+      env: CONFIGURE_FLAGS="                 --disable-libwebp"
+    - compiler: gcc
+      arch: ppc64le
+      dist: xenial
+      env: CONFIGURE_FLAGS="--disable-gcrypt --disable-libwebp --disable-translation"
+    - compiler: gcc
+      arch: ppc64le
+      dist: xenial
+      env: CONFIGURE_FLAGS="--disable-png"
+      
+
+
+


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.